### PR TITLE
quick reply buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This wrapper has the following functions:
 * send_action(recipient_id, action)
 * send_raw(payload)
 * get_user_info(recipient_id)
+* send_quickreply(recipient_id,quick_reply_message,reply_options)
 
 You can see the code/documentation for there in [bot.py](pymessenger/bot.py).
 
@@ -86,6 +87,25 @@ bot = Bot(<access_token>)
 image_url = "http://url/to/image.png"
 bot.send_image_url(recipient_id, image_url)
 ```
+##### Sending quick reply buttons
+
+```python
+
+from pymessenger.bot import Bot
+bot = Bot(<access_token>)
+
+# text which is shown
+quick_reply_message = "What's your favorite House in Game of Thrones?"
+# these are the buttons. You don't have to pass in a payload. All you have to do
+# is pass in a tuple containing `button_text` and `payload` in a list
+# any number of buttons can be added 
+# format : (["button_text1","payload1"],["button_text2"],"payload2")
+quick_rep_option = (["Stark","stark_payload"],["Lannister","lan_payload"],["Targaryan","tar_payload"],["none","None"])
+bot.send_quickreply(recipient_id,quick_reply_message,quick_rep_option)
+
+
+```
+
 
 ### Todo
 
@@ -100,5 +120,3 @@ bot.send_image_url(recipient_id, image_url)
 ![Screenshot of Echo Facebook Bot](https://cloud.githubusercontent.com/assets/68039/14516627/905c84ae-0237-11e6-918e-2c2ae9352f7d.png)
 
 You can find an example of an Echo Facebook Bot in ```examples/```
-
-

--- a/pymessenger/bot.py
+++ b/pymessenger/bot.py
@@ -306,6 +306,7 @@ class Bot:
 #quick_replies stuff
     def QuickReply_Send(self,user_id,text,reply_payload):
         # quick reply for messenger
+        # this method sends the request to fb
         params = {
             "access_token":self.access_token,
         }
@@ -331,6 +332,7 @@ class Bot:
         # pass in a tuple-of-list / list-of-lists
         # example : (['title1','payload'],['title2','payload'])
         quick_btns = []
+        # constructs the payload 
         for i in range(len(qk_payload)):
             quick_btns.append(
                 {
@@ -341,8 +343,9 @@ class Bot:
             )
         return quick_btns
 
-    def QuickReply_SendButtons(self,recipient_id,quick_reply_message,reply_options):
-        # sends the quick reply button
+    def send_quickreply(self,recipient_id,quick_reply_message,reply_options):
+        # use this method to send quick replies
+        # this method puts everything together
         # automatically constructs the payload for the buttons from the list
         reply_payload = QuickReply_CreatePayload(reply_options)
         QuickReply_Send(token = token,

--- a/pymessenger/bot.py
+++ b/pymessenger/bot.py
@@ -302,3 +302,51 @@ class Bot:
     def _send_payload(self, payload):
         """ Deprecated, use send_raw instead """
         return self.send_raw(payload)
+
+#quick_replies stuff
+    def QuickReply_Send(self,user_id,text,reply_payload):
+        # quick reply for messenger
+        params = {
+            "access_token":self.access_token,
+        }
+        payload = {
+          "recipient":{"id":user_id,},
+          "message":{
+            "text":"{}".format(text),
+            "quick_replies":reply_payload,
+          }
+        }
+        requests.post(
+            "https://graph.facebook.com/v2.6/me/messages",
+            params=params,
+            data=payload,
+            headers={
+                'Content-type': 'application/json'
+            }
+        )
+
+    # quick replies
+    def QuickReply_CreatePayload(self,qk_payload):
+        # this function constructs and returns a payload for the the quick reply button payload
+        # pass in a tuple-of-list / list-of-lists
+        # example : (['title1','payload'],['title2','payload'])
+        quick_btns = []
+        for i in range(len(qk_payload)):
+            quick_btns.append(
+                {
+                    "content_type":"text",
+                    "title":qk_payload[i][0],
+                    "payload":qk_payload[i][1],
+                }
+            )
+        return quick_btns
+
+    def QuickReply_SendButtons(self,recipient_id,quick_reply_message,reply_options):
+        # sends the quick reply button
+        # automatically constructs the payload for the buttons from the list
+        reply_payload = QuickReply_CreatePayload(reply_options)
+        QuickReply_Send(token = token,
+            user_id = recipient_id,
+            text = "{}".format(quick_reply_message),
+            reply_payload = reply_payload,
+        )


### PR DESCRIPTION
Added quick reply to pymessenger. Creating and passing a payload is not needed to display quick reply buttons. Just passing a tuple containing the `button_text` and `payload text` will create the buttons. Now, any number of buttons can be added in quick replies. I've tested it on my bot, works well.
Please test it and let me know if it has any problems.

the format for creating reply_options:
`
options = (
             ["button1","payload1"],
             ["button2","payload2"],
)
`
example:
```python

from pymessenger.bot import Bot
bot = Bot(<access_token>)
reply_message = "Choose any number"
reply_options = (["one","@one"],["two","@two"])
bot.send_quickreply(recipient_id,reply_message,reply_options)
```

Thanks!



