### PR TITLE
added send_get_started/send_persistent_menu feature and updated readme/contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,3 +4,4 @@ Special thanks to the following people who has contributed to this project!
 * [h4ck3rk3y](http://github.com/h4ck3rk3y)
 * [bildzeitung](https://github.com/bildzeitung)
 * [Cretezy](https://github.com/Cretezy)
+* [Onyenanu](https://github.com/madewithkode)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ This wrapper has the following functions:
 * send_action(recipient_id, action)
 * send_raw(payload)
 * get_user_info(recipient_id)
+* send_get_started(gs_obj)
+* send_persistent_menu(pm_obj)
 
 You can see the code/documentation for there in [bot.py](pymessenger/bot.py).
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ This wrapper has the following functions:
 * send_action(recipient_id, action)
 * send_raw(payload)
 * get_user_info(recipient_id)
-* send_get_started(gs_obj)
-* send_persistent_menu(pm_obj)
+* set_get_started(gs_obj)
+* set_persistent_menu(pm_obj)
+* remove_get_started()
+* remove_persistent_menu()
 
 You can see the code/documentation for there in [bot.py](pymessenger/bot.py).
 

--- a/pymessenger/bot.py
+++ b/pymessenger/bot.py
@@ -302,3 +302,37 @@ class Bot:
     def _send_payload(self, payload):
         """ Deprecated, use send_raw instead """
         return self.send_raw(payload)
+
+    def send_get_started(self, gs_obj):
+        """Send a get started button shown on welcome screen for first time users
+        https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/get-started-button
+        Input:
+          gs_obj: Your formatted get_started object as described by the API docs
+        Output:
+          Response from API as <dict>
+        """
+        request_endpoint = '{0}/me/messenger_profile'.format(self.graph_url)
+        response = requests.post(
+            request_endpoint,
+            params = self.auth_args,
+            json = gs_obj
+        )
+        result = response.json()
+        return result
+
+    def send_persistent_menu(self, pm_obj):
+        """Send a persistent_menu that stays same for every user. Before you can use this, make sure to have set a get started button.
+        https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/persistent-menu
+        Input:
+          pm_obj: Your formatted persistent menu object as described by the API docs
+        Output:
+          Response from API as <dict>
+        """
+        request_endpoint = '{0}/me/messenger_profile'.format(self.graph_url)
+        response = requests.post(
+            request_endpoint,
+            params = self.auth_args,
+            json = pm_obj
+        )
+        result = response.json()
+        return result

--- a/pymessenger/bot.py
+++ b/pymessenger/bot.py
@@ -303,8 +303,8 @@ class Bot:
         """ Deprecated, use send_raw instead """
         return self.send_raw(payload)
 
-    def send_get_started(self, gs_obj):
-        """Send a get started button shown on welcome screen for first time users
+    def set_get_started(self, gs_obj):
+        """Set a get started button shown on welcome screen for first time users
         https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/get-started-button
         Input:
           gs_obj: Your formatted get_started object as described by the API docs
@@ -320,8 +320,8 @@ class Bot:
         result = response.json()
         return result
 
-    def send_persistent_menu(self, pm_obj):
-        """Send a persistent_menu that stays same for every user. Before you can use this, make sure to have set a get started button.
+    def set_persistent_menu(self, pm_obj):
+        """Set a persistent_menu that stays same for every user. Before you can use this, make sure to have set a get started button.
         https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/persistent-menu
         Input:
           pm_obj: Your formatted persistent menu object as described by the API docs
@@ -336,3 +336,35 @@ class Bot:
         )
         result = response.json()
         return result
+
+    def remove_get_started(self):
+            """delete get started button.
+            https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/#delete
+            Output:
+            Response from API as <dict>
+            """
+            delete_obj = {"fields": ["get_started"]}
+            request_endpoint = '{0}/me/messenger_profile'.format(self.graph_url)
+            response = requests.delete(
+                request_endpoint,
+                params = self.auth_args,
+                json = delete_obj
+            )
+            result = response.json()
+            return result
+
+    def remove_persistent_menu(self):
+            """delete persistent menu.
+            https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/#delete
+            Output:
+            Response from API as <dict>
+            """
+            delete_obj = {"fields": ["persistent_menu"]}
+            request_endpoint = '{0}/me/messenger_profile'.format(self.graph_url)
+            response = requests.delete(
+                request_endpoint,
+                params = self.auth_args,
+                json = delete_obj
+            )
+            result = response.json()
+            return result


### PR DESCRIPTION
I added functions to explicitly send [get_started_buttons](https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/get-started-button) and also send [persistent_menus](https://developers.facebook.com/docs/messenger-platform/send-messages/persistent-menu/). Having built messenger bots using Pymessenger, I believe this is a needed and handy feature.