### PR TITLE
Added the ability to send payload directly to Messenger

### DIFF
--- a/pymessenger/bot.py
+++ b/pymessenger/bot.py
@@ -160,7 +160,7 @@ class Bot:
             }
         }, notification_type)
 
-    def send_custom_payload(self, recipient_id, payload, notification_type=NotificationType.regular):
+    def send_custom_message(self, recipient_id, payload, notification_type=NotificationType.regular):
         """This allows users send custom data to the Messenger API.
         This is best for cases where Messenger releases new features 
         And the PyMessenger team hasn't specifically implemented that feature

--- a/pymessenger/bot.py
+++ b/pymessenger/bot.py
@@ -160,6 +160,18 @@ class Bot:
             }
         }, notification_type)
 
+    def send_custom_payload(self, recipient_id, payload, notification_type=NotificationType.regular):
+        """This allows users send custom data to the Messenger API.
+        This is best for cases where Messenger releases new features 
+        And the PyMessenger team hasn't specifically implemented that feature
+        Input:
+            recipient_id: recipient id to send to
+            payload: dictionary containing raw request payload (requested by Messenger)
+        Output:
+            Response from API as <dict>
+        """
+        return self.send_message(recipient_id, payload, notification_type)
+
     def send_action(self, recipient_id, action, notification_type=NotificationType.regular):
         """Send typing indicators or send read receipts to the specified recipient.
         https://developers.facebook.com/docs/messenger-platform/send-api-reference/sender-actions


### PR DESCRIPTION
Provided a function users can use to send custom messages following Messenger's API structure.

This way, they can organize their message request or even quick replies just anyhow it would make sense for them.