### PR TITLE
Element to use default_action

### DIFF
--- a/pymessenger/__init__.py
+++ b/pymessenger/__init__.py
@@ -5,7 +5,7 @@ from .bot import Bot
 
 
 class Element(dict):
-    __acceptable_keys = ['title', 'item_url', 'image_url', 'subtitle', 'buttons']
+    __acceptable_keys = ['title', 'default_action', 'image_url', 'subtitle', 'buttons']
 
     def __init__(self, *args, **kwargs):
         if six.PY2:


### PR DESCRIPTION
Replaced `item_url` with `default_action`. 

Couldn't find what `item_url` is exactly, on [Facebook's docs ](https://developers.facebook.com/docs/messenger-platform/reference/templates/generic) for the generic template 